### PR TITLE
Fix linking against Graphviz that is not installed in system

### DIFF
--- a/cmake/FindGraphviz.cmake
+++ b/cmake/FindGraphviz.cmake
@@ -1,130 +1,170 @@
-# - Find Graphviz
-# Find the Graphviz includes and libraries
-# This module defines the IMPORTED targets if found:
-#  Graphviz::dot - The dot executable
-#  Graphviz::cdt - The cdt library
-#  Graphviz::gvc - The gvc library
-#  Graphviz::cgraph - The cgraph library
-#  Graphviz::graph - The graph library
-#  Graphviz::pathplan - The pathplan library
+# - Try to find Graphviz
+# Once done this will define
 #
-# All variables are internal. Consumers use the IMPORTED targets directly.
+#  GRAPHVIZ_FOUND - system has Graphviz
+#  GRAPHVIZ_INCLUDE_DIR - the Graphviz include directory
+#  GRAPHVIZ_LIBRARY - Link these to use Graphviz
+#  GRAPHVIZ_VERSION = The value of PACKAGE_VERSION defined in graphviz_version.h
+#  GRAPHVIZ_MAJOR_VERSION = The library major version number
+#  GRAPHVIZ_MINOR_VERSION = The library minor version number
+#  GRAPHVIZ_PATCH_VERSION = The library patch version number
+#  GRAPHVIZ_COMPILE_FLAGS = List of compile flags needed by the GraphViz installation headers
+#
+# This module reads hints about search locations from the following env or cache variables:
+#  GRAPHVIZ_ROOT          - Graphviz installation prefix
+#                           (containing bin/, include/, etc.)
 
-#=============================================================================
-# Copyright 2014 Stephen Kelly <stephen.kelly@kdab.com>
-#
-# Distributed under the OSI-approved BSD License (the "License");
-# see accompanying file Copyright.txt for details.
-#
-# This software is distributed WITHOUT ANY WARRANTY; without even the
-# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-# See the License for more information.
-#=============================================================================
+# Copyright (c) 2009, Adrien Bustany, <madcat@mymadcat.com>
+# Copyright (c) 2013-2015 Kevin Funk <kevin.funk@kdab.com>
+
+# Version computation and some cleanups by Allen Winter <allen.winter@kdab.com>
+# Bug fixing for WIN32 by Guillaume Jacquenot <guillaume.jacquenot@gmail.com>
+# Copyright (c) 2012-2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+
+# Redistribution and use is allowed according to the terms of the GPLv3+ license.
 
 include(CheckIncludeFiles)
+include(CMakePushCheckState)
 
-if (Graphviz_ROOT)
-    set(_Graphviz_ROOT ${Graphviz_ROOT})
+if(NOT GRAPHVIZ_MIN_VERSION)
+  set(GRAPHVIZ_MIN_VERSION "2.00")
+endif()
+
+if(GRAPHVIZ_INCLUDE_DIR AND GRAPHVIZ_CDT_LIBRARY
+    AND (GRAPHVIZ_CGRAPH_LIBRARY OR GRAPHVIZ_GRAPH_LIBRARY) AND GRAPHVIZ_PATHPLAN_LIBRARY)
+  set(GRAPHVIZ_FIND_QUIETLY TRUE)
+endif()
+
+if (GRAPHVIZ_ROOT)
+    set(_GRAPHVIZ_ROOT ${GRAPHVIZ_ROOT})
 else()
-    set(_Graphviz_ROOT $ENV{Graphviz_ROOT})
+    set(_GRAPHVIZ_ROOT $ENV{GRAPHVIZ_ROOT})
 endif()
 
-find_program(DOT_TOOL dot HINTS ${_Graphviz_ROOT}/bin)
-
-if (WIN32 AND NOT _Graphviz_ROOT AND NOT DOT_TOOL)
-  message(STATUS "No way to find Graphviz. Set the path to the DOT_TOOL in the cache.")
-  set(Graphviz_FOUND FALSE)
-  return()
-endif()
-
-if(DOT_TOOL)
-  add_executable(Graphviz::dot IMPORTED)
-  set_property(TARGET Graphviz::dot PROPERTY IMPORTED_LOCATION ${DOT_TOOL})
-  if(NOT _Graphviz_ROOT AND WIN32)
-    get_filename_component(_Graphviz_ROOT ${DOT_TOOL} PATH)
+if(NOT _GRAPHVIZ_ROOT)
+  if(WIN32)
+      find_program(DOT_TOOL dot)
+      get_filename_component(_GRAPHVIZ_ROOT ${DOT_TOOL} PATH)
   endif()
 endif()
 
-find_path(Graphviz_INCLUDE_DIR NAMES graphviz/graphviz_version.h
-  HINTS ${_Graphviz_ROOT}
-)
-
-if(Graphviz_INCLUDE_DIR AND EXISTS "${Graphviz_INCLUDE_DIR}/graphviz/graphviz_version.h")
-    file(STRINGS "${Graphviz_INCLUDE_DIR}/graphviz/graphviz_version.h" Graphviz_H REGEX "PACKAGE_VERSION")
-    string(REGEX REPLACE "^#define[\t ]+PACKAGE_VERSION[\t ]+\"([^\"]*)\".*" "\\1" Graphviz_VERSION "${Graphviz_H}")
-
-    string( REGEX REPLACE "([0-9]+).*" "\\1" Graphviz_VERSION_MAJOR "${Graphviz_VERSION}" )
-    string( REGEX REPLACE "[0-9]+\\.([0-9]+).*" "\\1" Graphviz_VERSION_MINOR "${Graphviz_VERSION}" )
-    string( REGEX REPLACE "[0-9]+\\.[0-9]+\\.([0-9]+).*" "\\1" Graphviz_VERSION_PATCH "${Graphviz_VERSION}" )
-elseif(DOT_TOOL)
-    # Graphviz ships without graphviz_version.h on Windows.
-    find_path(Graphviz_INCLUDE_DIR NAMES graphviz/graph.h graphviz/cgraph.h
-      HINTS ${_Graphviz_ROOT}/include
-    )
-    execute_process(COMMAND ${DOT_TOOL} -V OUTPUT_VARIABLE DOT_VERSION_OUTPUT ERROR_VARIABLE DOT_VERSION_OUTPUT OUTPUT_QUIET)
-    string(REGEX MATCH "([0-9]+\\.[0-9]+\\.[0-9]+)" Graphviz_VERSION "${DOT_VERSION_OUTPUT}")
-    string(REPLACE "." ";" VL ${Graphviz_VERSION})
-    list(GET VL 0 Graphviz_VERSION_MAJOR)
-    list(GET VL 1 Graphviz_VERSION_MINOR)
-    list(GET VL 2 Graphviz_VERSION_PATCH)
+if(_GRAPHVIZ_ROOT)
+  set(_GRAPHVIZ_INCLUDE_DIR ${_GRAPHVIZ_ROOT}/include)
+  set(_GRAPHVIZ_LIBRARY_DIR ${_GRAPHVIZ_ROOT}/lib)
+  set(_GRAPHVIZ_FIND_OPTS NO_DEFAULT_PATH)
+else()
+  set(_GRAPHVIZ_FIND_OPTS "")
 endif()
+
+find_path(GRAPHVIZ_INCLUDE_DIR NAMES graphviz/graph.h graphviz/cgraph.h
+  HINTS ${_GRAPHVIZ_INCLUDE_DIR}
+  ${_GRAPHVIZ_FIND_OPTS})
 
 if(WIN32)
-  set(Graphviz_LIB_PATH_SUFFIX_RELEASE "release/lib")
-  set(Graphviz_LIB_PATH_SUFFIX_DEBUG "debug/lib")
-endif()
-
-set(gv_libs cdt gvc cgraph graph pathplan)
-foreach(lib ${gv_libs})
-  set(build_types RELEASE)
-  if (WIN32)
-    list(APPEND build_types DEBUG)
+  if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    set(GRAPHVIZ_LIB_PATH_SUFFIX "release/lib")
+  else()
+    set(GRAPHVIZ_LIB_PATH_SUFFIX "debug/lib")
   endif()
-  foreach(BUILD_TYPE ${build_types})
-    string(TOUPPER ${lib} libupper)
-    find_library(Graphviz_${libupper}_LIBRARY_${BUILD_TYPE} NAMES ${lib}
-      HINTS ${_Graphviz_ROOT}/lib PATH_SUFFIXES ${Graphviz_LIB_PATH_SUFFIX_${BUILD_TYPE}})
-  endforeach()
-endforeach()
-
-include("${CMAKE_ROOT}/Modules/FindPackageHandleStandardArgs.cmake")
-find_package_handle_standard_args(Graphviz
-                                  FOUND_VAR Graphviz_FOUND
-                                  REQUIRED_VARS Graphviz_INCLUDE_DIR Graphviz_CDT_LIBRARY_RELEASE Graphviz_GVC_LIBRARY_RELEASE Graphviz_PATHPLAN_LIBRARY_RELEASE
-                                  VERSION_VAR Graphviz_VERSION)
-
-if(NOT Graphviz_CGRAPH_LIBRARY_RELEASE AND NOT Graphviz_GRAPH_LIBRARY_RELEASE)
-  set(Graphviz_FOUND FALSE)
+else()
+  set(GRAPHVIZ_LIB_PATH_SUFFIX)
 endif()
 
-# work-around issue in Graphviz headers for >=2.26.0,  also see: https://github.com/KDAB/GammaRay/issues/79
-set(_graphviz_extra_compile_definitions "")
-if (NOT (Graphviz_VERSION VERSION_LESS 2.26.0))
-    check_include_files(string.h have_string_h)
-    if (have_string_h)
-        list(APPEND _graphviz_extra_compile_definitions HAVE_STRING_H)
-    endif()
-endif()
+find_library(GRAPHVIZ_CDT_LIBRARY NAMES cdt
+  HINTS ${_GRAPHVIZ_LIBRARY_DIR} PATH_SUFFIXES ${GRAPHVIZ_LIB_PATH_SUFFIX}
+  ${_GRAPHVIZ_FIND_OPTS})
+find_library(GRAPHVIZ_GVC_LIBRARY NAMES gvc
+  HINTS ${_GRAPHVIZ_LIBRARY_DIR} PATH_SUFFIXES ${GRAPHVIZ_LIB_PATH_SUFFIX}
+  ${_GRAPHVIZ_FIND_OPTS})
+find_library(GRAPHVIZ_CGRAPH_LIBRARY NAMES cgraph
+  HINTS ${_GRAPHVIZ_LIBRARY_DIR} PATH_SUFFIXES ${GRAPHVIZ_LIB_PATH_SUFFIX}
+  ${_GRAPHVIZ_FIND_OPTS})
+find_library(GRAPHVIZ_GRAPH_LIBRARY NAMES graph
+  HINTS ${_GRAPHVIZ_LIBRARY_DIR} PATH_SUFFIXES ${GRAPHVIZ_LIB_PATH_SUFFIX}
+  ${_GRAPHVIZ_FIND_OPTS})
+find_library(GRAPHVIZ_PATHPLAN_LIBRARY NAMES pathplan
+  HINTS ${_GRAPHVIZ_LIBRARY_DIR} PATH_SUFFIXES ${GRAPHVIZ_LIB_PATH_SUFFIX}
+  ${_GRAPHVIZ_FIND_OPTS})
 
-foreach(lib ${gv_libs})
-  string(TOUPPER ${lib} libupper)
-  if (Graphviz_${libupper}_LIBRARY_RELEASE)
-    add_library(Graphviz::${lib} UNKNOWN IMPORTED)
-    set_property(TARGET Graphviz::${lib} APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
-    set_property(TARGET Graphviz::${lib} PROPERTY INTERFACE_COMPILE_DEFINITIONS ${_graphviz_extra_compile_definitions})
-    set_property(TARGET Graphviz::${lib} PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${Graphviz_INCLUDE_DIR})
-    set_property(TARGET Graphviz::${lib} PROPERTY IMPORTED_LOCATION_RELEASE ${Graphviz_${libupper}_LIBRARY_RELEASE})
-    if (Graphviz_${libupper}_LIBRARY_DEBUG)
-      set_property(TARGET Graphviz::${lib} APPEND PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
-      set_property(TARGET Graphviz::${lib} PROPERTY IMPORTED_LOCATION_DEBUG ${Graphviz_${libupper}_LIBRARY_DEBUG})
-    endif()
+cmake_push_check_state()
+set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES} ${GRAPHVIZ_INCLUDE_DIR})
+check_include_files(graphviz/graphviz_version.h HAVE_GRAPHVIZ_VERSION_H)
+cmake_pop_check_state()
+
+if(GRAPHVIZ_INCLUDE_DIR AND GRAPHVIZ_CDT_LIBRARY AND GRAPHVIZ_GVC_LIBRARY
+    AND (GRAPHVIZ_CGRAPH_LIBRARY OR GRAPHVIZ_GRAPH_LIBRARY) AND GRAPHVIZ_PATHPLAN_LIBRARY)
+  if(HAVE_GRAPHVIZ_VERSION_H OR WIN32)
+    set(GRAPHVIZ_FOUND TRUE)
   endif()
-endforeach()
+else()
+  set(GRAPHVIZ_FOUND FALSE)
+endif()
 
-unset(gv_libs)
+# Ok, now compute the version and make sure its greater then the min required
+if(GRAPHVIZ_FOUND)
+  if(NOT WIN32)
+    set(FIND_GRAPHVIZ_VERSION_SOURCE
+      "#include <graphviz/graphviz_version.h>\n#include <stdio.h>\n int main()\n {\n printf(\"%s\",PACKAGE_VERSION);return 1;\n }\n")
+    set(FIND_GRAPHVIZ_VERSION_SOURCE_FILE ${CMAKE_BINARY_DIR}/CMakeTmp/FindGRAPHVIZ.cxx)
+    file(WRITE "${FIND_GRAPHVIZ_VERSION_SOURCE_FILE}" "${FIND_GRAPHVIZ_VERSION_SOURCE}")
 
-if (TARGET Graphviz::cgraph)
-  # you must add this define when using cgraph from graphviz
-  # some headers check for this define (see for example graphviz/types.h header)
-  set_property(TARGET Graphviz::cgraph APPEND PROPERTY INTERFACE_COMPILE_DEFINITIONS WITH_CGRAPH)
+    set(FIND_GRAPHVIZ_VERSION_ADD_INCLUDES
+      "-DINCLUDE_DIRECTORIES:STRING=${GRAPHVIZ_INCLUDE_DIR}")
+
+    if(NOT CMAKE_CROSSCOMPILING)
+    try_run(RUN_RESULT COMPILE_RESULT
+      ${CMAKE_BINARY_DIR}
+      ${FIND_GRAPHVIZ_VERSION_SOURCE_FILE}
+      CMAKE_FLAGS "${FIND_GRAPHVIZ_VERSION_ADD_INCLUDES}"
+      RUN_OUTPUT_VARIABLE GRAPHVIZ_VERSION)
+    endif()
+
+    if(COMPILE_RESULT AND RUN_RESULT EQUAL 1 AND NOT CMAKE_CROSSCOMPILING)
+      message(STATUS "Found Graphviz version ${GRAPHVIZ_VERSION}")
+      if(${GRAPHVIZ_VERSION} VERSION_LESS ${GRAPHVIZ_MIN_VERSION})
+        message(STATUS "Graphviz version ${GRAPHVIZ_VERSION} is too old. At least version ${GRAPHVIZ_MIN_VERSION} is needed.")
+        set(GRAPHVIZ_FOUND FALSE)
+        set(GRAPHVIZ_INCLUDE_DIR "")
+        set(GRAPHVIZ_CDT_LIBRARY "")
+        set(GRAPHVIZ_GVC_LIBRARY "")
+        set(GRAPHVIZ_CGRAPH_LIBRARY "")
+        set(GRAPHVIZ_GRAPH_LIBRARY "")
+        set(GRAPHVIZ_PATHPLAN_LIBRARY "")
+      else(${GRAPHVIZ_VERSION} VERSION_LESS ${GRAPHVIZ_MIN_VERSION})
+        # Compute the major and minor version numbers
+        if(NOT CMAKE_CROSSCOMPILING)
+          string(REPLACE "." ";" VL ${GRAPHVIZ_VERSION})
+          list(GET VL 0 GRAPHVIZ_MAJOR_VERSION)
+          list(GET VL 1 GRAPHVIZ_MINOR_VERSION)
+          list(GET VL 2 GRAPHVIZ_PATCH_VERSION)
+        endif()
+      endif(${GRAPHVIZ_VERSION} VERSION_LESS ${GRAPHVIZ_MIN_VERSION})
+    else()
+      if(NOT CMAKE_CROSSCOMPILING)
+        message(FATAL_ERROR "Unable to compile or run the graphviz version detection program.")
+      endif()
+    endif()
+  elseif(WIN32)
+    find_program(DOT_TOOL dot PATHS ${_GRAPHVIZ_ROOT}/bin)
+    execute_process(COMMAND ${DOT_TOOL} -V OUTPUT_VARIABLE DOT_VERSION_OUTPUT ERROR_VARIABLE DOT_VERSION_OUTPUT OUTPUT_QUIET)
+    string(REGEX MATCH "([0-9]+\\.[0-9]+\\.[0-9]+)" GRAPHVIZ_VERSION "${DOT_VERSION_OUTPUT}")
+    string(REPLACE "." ";" VL ${GRAPHVIZ_VERSION})
+    list(GET VL 0 GRAPHVIZ_MAJOR_VERSION)
+    list(GET VL 1 GRAPHVIZ_MINOR_VERSION)
+    list(GET VL 2 GRAPHVIZ_PATCH_VERSION)
+  endif()
+
+  set(GRAPHVIZ_COMPILE_FLAGS "")
+  check_include_files(string.h HAVE_STRING_H)
+  if (HAVE_STRING_H)
+    list(APPEND GRAPHVIZ_COMPILE_FLAGS "-DHAVE_STRING_H=1")
+  endif()
+
+  if(NOT GRAPHVIZ_FIND_QUIETLY)
+    message(STATUS "Found Graphviz: ${GRAPHVIZ_CDT_LIBRARY} ${GRAPHVIZ_GVC_LIBRARY} ${GRAPHVIZ_CGRAPH_LIBRARY} ${GRAPHVIZ_GRAPH_LIBRARY} ${GRAPHVIZ_PATHPLAN_LIBRARY}")
+  endif()
+else()
+  if(GRAPHVIZ_FIND_REQUIRED)
+    message(FATAL_ERROR "Could NOT find Graphivz")
+  endif()
 endif()

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -48,7 +48,7 @@ if(Qt5RemoteObjects_FOUND)
   )
 endif()
 
-if(Graphviz_FOUND)
+if(GRAPHVIZ_FOUND)
   list(APPEND LIB_SRCS
     layout/graphvizlayout/gvutils.cpp
     layout/graphvizlayout/graphvizlayerlayouter.cpp
@@ -75,21 +75,22 @@ set_target_properties(kdstatemachineeditor_core PROPERTIES
 )
 generate_export_header(kdstatemachineeditor_core EXPORT_FILE_NAME kdsme_core_export.h BASE_NAME KDSME_CORE)
 
-if(Graphviz_FOUND)
-  target_link_libraries(kdstatemachineeditor_core LINK_PRIVATE Graphviz::gvc)
+if(GRAPHVIZ_FOUND)
+  target_link_libraries(kdstatemachineeditor_core LINK_PUBLIC ${GRAPHVIZ_GVC_LIBRARY})
 
-  if(TARGET Graphviz::cgraph AND Graphviz_VERSION VERSION_GREATER 2.30.0)
+  if(GRAPHVIZ_CGRAPH_LIBRARY AND GRAPHVIZ_VERSION VERSION_GREATER 2.30.0)
     message(STATUS "Enabling use of experimental 'cgraph' library of GraphViz")
-    target_link_libraries(kdstatemachineeditor_core LINK_PRIVATE Graphviz::cgraph)
+    target_link_libraries(kdstatemachineeditor_core LINK_PUBLIC ${GRAPHVIZ_CGRAPH_LIBRARY})
   else()
-    target_link_libraries(kdstatemachineeditor_core LINK_PRIVATE Graphviz::graph)
+    target_link_libraries(kdstatemachineeditor_core LINK_PUBLIC ${GRAPHVIZ_GRAPH_LIBRARY})
   endif()
   list(APPEND LIB_EXTRA_INCLUDES
+    ${GRAPHVIZ_INCLUDE_DIR}
     # TODO: Work-around issue in graphviz/types.h header
     # <cgraph.h> is included there, but it should rather be "cgraph.h"
-    ${Graphviz_INCLUDE_DIR}/graphviz
+    ${GRAPHVIZ_INCLUDE_DIR}/graphviz
   )
-  target_compile_definitions(kdstatemachineeditor_core PRIVATE -DGRAPHVIZ_MAJOR_VERSION=${Graphviz_VERSION_MAJOR} -DGRAPHVIZ_MINOR_VERSION=${Graphviz_VERSION_MINOR})
+  target_compile_definitions(kdstatemachineeditor_core PRIVATE -DGRAPHVIZ_MAJOR_VERSION=${GRAPHVIZ_MAJOR_VERSION} -DGRAPHVIZ_MINOR_VERSION=${GRAPHVIZ_MINOR_VERSION})
 endif()
 
 if(Qt5RemoteObjects_FOUND)


### PR DESCRIPTION
Linking of the executables fails when privately linking against
Graphviz libraries that are not installed in a system default location.
Also just take the FindGraphviz.cmake version over from GammaRay, which
- synchronizes the two repositories which obviously deviated quite a bit
- fixes GammaRay build against KDSME built against Graphviz libs that
  are not installed in a system default location