### PR TITLE
Fix assert

### DIFF
--- a/src/view/quick/quicksceneitem.cpp
+++ b/src/view/quick/quicksceneitem.cpp
@@ -98,7 +98,7 @@ StateMachineScene* QuickSceneItem::scene() const
 void QuickSceneItem::setScene(StateMachineScene* scene)
 {
     Q_ASSERT(scene);
-    Q_ASSERT(!m_scene);
+    Q_ASSERT(!m_scene || scene == m_scene);
 
     m_scene = scene;
 }


### PR DESCRIPTION
Due to platform variations, it seems setScene can be called several
times with the same scene. Change the assertion to handle that case.