### PR TITLE
Fix PVS-Studio V501 "identical sub-expressions to the left and to the right of the '&&'"

### DIFF
--- a/src/view/command/modifyelementcommand.cpp
+++ b/src/view/command/modifyelementcommand.cpp
@@ -112,7 +112,7 @@ bool ModifyElementCommand::mergeWith(const QUndoCommand* other)
 
 void KDSME::ModifyElementCommand::updateText()
 {
-    const QString itemLabel = m_item && m_item ? m_item->label() : tr("<Unknown>");
+    const QString itemLabel = (m_item && !m_item.isNull()) ? m_item->label() : tr("<Unknown>");
 
     switch (m_operation) {
     case MoveOperation:


### PR DESCRIPTION
modifyelementcommand.cpp:115: error: V501 There are identical sub-expressions to the left and to the right of the '&&' operator: m_item && m_item