### PR TITLE
.gitignore ignore "/compile_commands.json"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.orig
 *.out
 CMakeLists.txt.user*
+/compile_commands.json
 
 # from kdiff3
 *.BACKUP.*


### PR DESCRIPTION
This file is generated by kdesrc-build/CMake/clangd integration.