### PR TITLE
QtXmlPatterns does not exist in Qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,13 +129,16 @@ set_package_properties(
     PURPOSE "Needed for the Qt SCXML adapter (adapter itself depends on Qt RemoteObjects)"
 )
 
-find_package(Qt${Qt_VERSION_MAJOR}XmlPatterns ${QT_MIN_VERSION} CONFIG QUIET)
-set_package_properties(
-    Qt${Qt_VERSION_MAJOR}XmlPatterns PROPERTIES
-    TYPE OPTIONAL
-    DESCRIPTION "Qt XmlPatterns library"
-    PURPOSE "Required for unit tests dealing with XML input/output"
-)
+# QtXmlPatterns is removed since Qt6
+if(NOT BUILD_QT6)
+    find_package(Qt5XmlPatterns ${QT_MIN_VERSION} CONFIG QUIET)
+    set_package_properties(
+        Qt5XmlPatterns PROPERTIES
+        TYPE OPTIONAL
+        DESCRIPTION "Qt5 XmlPatterns library"
+        PURPOSE "Required with Qt5 for unit tests dealing with XML input/output"
+    )
+endif()
 
 include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)

--- a/src/core/tests/CMakeLists.txt
+++ b/src/core/tests/CMakeLists.txt
@@ -16,9 +16,9 @@
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config-test.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config-test.h)
 
 # QtXmlPatterns fails badly on OSX -- see https://bugreports.qt-project.org/browse/QTBUG-40818
-if(Qt${Qt_VERSION_MAJOR}XmlPatterns_FOUND AND NOT APPLE)
+if(TARGET Qt5::XmlPatterns_FOUND AND NOT APPLE)
     add_definitions(-DUSE_QT_XMLPATTERNS_LIB)
-    list(APPEND KDSME_TESTHELPER_EXTRA_LIBS Qt${Qt_VERSION_MAJOR}::XmlPatterns)
+    list(APPEND KDSME_TESTHELPER_EXTRA_LIBS Qt5::XmlPatterns)
 endif()
 
 add_library(kdsme_testhelper STATIC parsehelper.cpp util.cpp)


### PR DESCRIPTION
Make it clear that QtXmlPatterns is for Qt5 builds only.