### PR TITLE
Standardize project to KDAB copyright policy

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -5,22 +5,22 @@ Source: https://www.github.com/KDAB/KDStateMachineEditor
 
 #misc source code
 Files: *.ui *.qrc *.scxml docs/api/Doxyfile.cmake src/view/qml/util/qmldir
-Copyright: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+Copyright: Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 License: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor
 
 #misc documentation
 Files: CHANGES INSTALL.txt README.md conan/README.txt data/scxml/README.txt docs/api/footer.html docs/KDStateMachineEditor-CopyrightAssignmentForm.pdf
-Copyright: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+Copyright: Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 License: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor
 
 #misc config files
 Files: .pre-commit-config.yaml .codespellrc .krazy .clang-tidy .gitignore appveyor.yml distro/* .clang-format .cmake-format.py .mdlrc .mdlrc.rb
-Copyright: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+Copyright: Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 License: BSD-3-Clause
 
 #artwork
 Files: screenshots/*.png src/view/icons/*.png  examples/qscxmldebugger/*.png docs/api/*.png
-Copyright: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+Copyright: Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 License: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor
 
 #3rdparty from KDE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KDAB State Machine Editor Library.
 #
-# SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Kevin Funk <kevin.funk@kdab.com>
 #
 # SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ Please submit your contributions or issue reports from our GitHub space at
 
 ## Licensing
 
-The KDAB State Machine Editor Library is (C) 2014-2023 Klarälvdalens Datakonsult AB (KDAB), and
-is licensed according to the terms of the [LGPL 2.1](LICENSES/LGPL-2.1-only.txt).
+The KDAB State Machine Editor Library is © Klarälvdalens Datakonsult AB (KDAB),
+and is licensed according to the terms of the [LGPL 2.1](LICENSES/LGPL-2.1-only.txt).
 
 Commercial licensing terms are available in the included file
 [LicenseRef-KDAB-KDStateMachineEditor.txt](LICENSES/LicenseRef-KDAB-KDStateMachineEditor.txt).

--- a/cmake/FindGraphviz.cmake
+++ b/cmake/FindGraphviz.cmake
@@ -15,7 +15,7 @@
 #                           (containing bin/, include/, etc.)
 
 # SPDX-FileCopyrightText: 2009, Adrien Bustany, <madcat@mymadcat.com>
-# SPDX-FileCopyrightText: 2012-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2012 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
 # Version computation and some cleanups by Allen Winter <allen.winter@kdab.com>
 # Bug fixing for WIN32 by Guillaume Jacquenot <guillaume.jacquenot@gmail.com>

--- a/cmake/KDSMEConfig.cmake
+++ b/cmake/KDSMEConfig.cmake
@@ -1,7 +1,6 @@
-#
 # This file is part of the KDAB State Machine Editor Library.
 #
-# SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Kevin Funk <kevin.funk@kdab.com>
 #
 # SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -1,8 +1,6 @@
-###############################################################################
-#
 # This file is part of the KDAB State Machine Editor Library.
 #
-# SPDX-FileCopyrightText: 2019-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2019 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Renato Araujo Oliveira Filho <renato.araujo@kdab.com>
 #
 # SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KDAB State Machine Editor Library.
 #
-# SPDX-FileCopyrightText: 2017-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2017 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Allen Winter <allen.winter@kdab.com>
 #
 # SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/docs/api/CMakeLists.txt
+++ b/docs/api/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KDAB State Machine Editor Library.
 #
-# SPDX-FileCopyrightText: 2017-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2017 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Allen Winter <allen.winter@kdab.com>
 #
 # SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/docs/api/footer.html
+++ b/docs/api/footer.html
@@ -1,7 +1,7 @@
     <hr>
     <div style="float: left;">
       <img src="kdab-logo-16x16.png">
-      <font style="font-weight: bold;">&copy; 2014-2023 Klar&auml;lvdalens Datakonsult AB (KDAB)</font>
+      <font style="font-weight: bold;">&copy; Klar&auml;lvdalens Datakonsult AB (KDAB)</font>
       <br>
       "The Qt, C++ and OpenGL Experts"<br>
       <a href="https://www.kdab.com/">https://www.kdab.com/</a>

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KDAB State Machine Editor Library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Kevin Funk <kevin.funk@kdab.com>
 #
 # SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/examples/config-examples.h.cmake
+++ b/examples/config-examples.h.cmake
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/examples/export/CMakeLists.txt
+++ b/examples/export/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KDAB State Machine Editor Library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Kevin Funk <kevin.funk@kdab.com>
 #
 # SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/examples/export/main.cpp
+++ b/examples/export/main.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/examples/layoutexport/CMakeLists.txt
+++ b/examples/layoutexport/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KDAB State Machine Editor Library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Kevin Funk <kevin.funk@kdab.com>
 #
 # SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/examples/layoutexport/main.cpp
+++ b/examples/layoutexport/main.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/examples/qscxmldebugger/CMakeLists.txt
+++ b/examples/qscxmldebugger/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KDAB State Machine Editor Library.
 #
-# SPDX-FileCopyrightText: 2016-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Kevin Funk <kevin.funk@kdab.com>
 #
 # SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/examples/qscxmldebugger/main.cpp
+++ b/examples/qscxmldebugger/main.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2016-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/examples/qsmdebugger/CMakeLists.txt
+++ b/examples/qsmdebugger/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KDAB State Machine Editor Library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Kevin Funk <kevin.funk@kdab.com>
 #
 # SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/examples/qsmdebugger/main.cpp
+++ b/examples/qsmdebugger/main.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/examples/scxmlimport/CMakeLists.txt
+++ b/examples/scxmlimport/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KDAB State Machine Editor Library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Kevin Funk <kevin.funk@kdab.com>
 #
 # SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/examples/scxmlimport/main.cpp
+++ b/examples/scxmlimport/main.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/examples/simplestatemachine/CMakeLists.txt
+++ b/examples/simplestatemachine/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KDAB State Machine Editor Library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Kevin Funk <kevin.funk@kdab.com>
 #
 # SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/examples/simplestatemachine/main.cpp
+++ b/examples/simplestatemachine/main.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KDAB State Machine Editor Library.
 #
-# SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Kevin Funk <kevin.funk@kdab.com>
 #
 # SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KDAB State Machine Editor Library.
 #
-# SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Kevin Funk <kevin.funk@kdab.com>
 #
 # SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/app/mainwindow.cpp
+++ b/src/app/mainwindow.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/app/mainwindow.h
+++ b/src/app/mainwindow.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/config-kdsme.h.cmake
+++ b/src/config-kdsme.h.cmake
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KDAB State Machine Editor Library.
 #
-# SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Kevin Funk <kevin.funk@kdab.com>
 #
 # SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/common/metatypedeclarations.h
+++ b/src/core/common/metatypedeclarations.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/debug.cpp
+++ b/src/core/debug.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/debug.h
+++ b/src/core/debug.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/export/abstractexporter.cpp
+++ b/src/core/export/abstractexporter.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/export/abstractexporter.h
+++ b/src/core/export/abstractexporter.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/export/qmlexporter.cpp
+++ b/src/core/export/qmlexporter.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/export/qmlexporter.h
+++ b/src/core/export/qmlexporter.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/export/scxmlexporter.cpp
+++ b/src/core/export/scxmlexporter.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/export/scxmlexporter.h
+++ b/src/core/export/scxmlexporter.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/export/svgexporter.cpp
+++ b/src/core/export/svgexporter.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Volker Krause <volker.krause@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/export/svgexporter.h
+++ b/src/core/export/svgexporter.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Volker Krause <volker.krause@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/import/abstractimporter.cpp
+++ b/src/core/import/abstractimporter.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/import/abstractimporter.h
+++ b/src/core/import/abstractimporter.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/import/scxmlimporter.cpp
+++ b/src/core/import/scxmlimporter.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/import/scxmlimporter.h
+++ b/src/core/import/scxmlimporter.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/kdsmeconstants.h
+++ b/src/core/kdsmeconstants.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/layout/graphvizlayout/graphviz_staticbuild.c
+++ b/src/core/layout/graphvizlayout/graphviz_staticbuild.c
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2016-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/layout/graphvizlayout/graphvizlayerlayouter.cpp
+++ b/src/core/layout/graphvizlayout/graphvizlayerlayouter.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/layout/graphvizlayout/graphvizlayerlayouter.h
+++ b/src/core/layout/graphvizlayout/graphvizlayerlayouter.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/layout/graphvizlayout/graphvizlayouter.cpp
+++ b/src/core/layout/graphvizlayout/graphvizlayouter.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/layout/graphvizlayout/graphvizlayouter.h
+++ b/src/core/layout/graphvizlayout/graphvizlayouter.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/layout/graphvizlayout/graphvizlayouterbackend.cpp
+++ b/src/core/layout/graphvizlayout/graphvizlayouterbackend.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/layout/graphvizlayout/graphvizlayouterbackend_p.h
+++ b/src/core/layout/graphvizlayout/graphvizlayouterbackend_p.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/layout/graphvizlayout/gvutils.cpp
+++ b/src/core/layout/graphvizlayout/gvutils.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/layout/graphvizlayout/gvutils.h
+++ b/src/core/layout/graphvizlayout/gvutils.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/layout/layerwiselayouter.cpp
+++ b/src/core/layout/layerwiselayouter.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/layout/layerwiselayouter.h
+++ b/src/core/layout/layerwiselayouter.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/layout/layouter.cpp
+++ b/src/core/layout/layouter.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/layout/layouter.h
+++ b/src/core/layout/layouter.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/layout/layoutimportexport.cpp
+++ b/src/core/layout/layoutimportexport.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/layout/layoutimportexport.h
+++ b/src/core/layout/layoutimportexport.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/layout/layoutproperties.cpp
+++ b/src/core/layout/layoutproperties.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/layout/layoutproperties.h
+++ b/src/core/layout/layoutproperties.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/layout/layoututils.cpp
+++ b/src/core/layout/layoututils.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/layout/layoututils.h
+++ b/src/core/layout/layoututils.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/model/element.cpp
+++ b/src/core/model/element.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/model/element.h
+++ b/src/core/model/element.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/model/element_p.h
+++ b/src/core/model/element_p.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/model/elementfactory.cpp
+++ b/src/core/model/elementfactory.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/model/elementfactory.h
+++ b/src/core/model/elementfactory.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/model/elementmodel.cpp
+++ b/src/core/model/elementmodel.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/model/elementmodel.h
+++ b/src/core/model/elementmodel.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/model/elementutil.cpp
+++ b/src/core/model/elementutil.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/model/elementutil.h
+++ b/src/core/model/elementutil.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/model/elementwalker.h
+++ b/src/core/model/elementwalker.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/model/runtimecontroller.cpp
+++ b/src/core/model/runtimecontroller.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/model/runtimecontroller.h
+++ b/src/core/model/runtimecontroller.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/model/state.cpp
+++ b/src/core/model/state.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/model/state.h
+++ b/src/core/model/state.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/model/transition.cpp
+++ b/src/core/model/transition.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/model/transition.h
+++ b/src/core/model/transition.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/tests/CMakeLists.txt
+++ b/src/core/tests/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KDAB State Machine Editor Library.
 #
-# SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Kevin Funk <kevin.funk@kdab.com>
 #
 # SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/tests/config-test.h.cmake
+++ b/src/core/tests/config-test.h.cmake
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/tests/parsehelper.cpp
+++ b/src/core/tests/parsehelper.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/tests/parsehelper.h
+++ b/src/core/tests/parsehelper.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/tests/test_layouter.cpp
+++ b/src/core/tests/test_layouter.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/tests/test_layoutinformation.cpp
+++ b/src/core/tests/test_layoutinformation.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/tests/test_layoutitem.cpp
+++ b/src/core/tests/test_layoutitem.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/tests/test_models.cpp
+++ b/src/core/tests/test_models.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/tests/test_qmlexport.cpp
+++ b/src/core/tests/test_qmlexport.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/tests/test_qsmintegration.cpp
+++ b/src/core/tests/test_qsmintegration.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/tests/test_scxmlexport.cpp
+++ b/src/core/tests/test_scxmlexport.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/tests/test_scxmlimport.cpp
+++ b/src/core/tests/test_scxmlimport.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/tests/test_statemachine.cpp
+++ b/src/core/tests/test_statemachine.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/tests/test_util.cpp
+++ b/src/core/tests/test_util.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/tests/util.cpp
+++ b/src/core/tests/util.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/tests/util.h
+++ b/src/core/tests/util.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/util/depthchecker.cpp
+++ b/src/core/util/depthchecker.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/util/depthchecker.h
+++ b/src/core/util/depthchecker.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/util/objecthelper.cpp
+++ b/src/core/util/objecthelper.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/util/objecthelper.h
+++ b/src/core/util/objecthelper.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/util/objecttreemodel.cpp
+++ b/src/core/util/objecttreemodel.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/util/objecttreemodel.h
+++ b/src/core/util/objecttreemodel.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/util/ringbuffer.h
+++ b/src/core/util/ringbuffer.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/core/util/treewalker.h
+++ b/src/core/util/treewalker.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/debuginterface/CMakeLists.txt
+++ b/src/debuginterface/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KDAB State Machine Editor Library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Kevin Funk <kevin.funk@kdab.com>
 #
 # SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/debuginterface/debuginterface.rep
+++ b/src/debuginterface/debuginterface.rep
@@ -1,6 +1,6 @@
 // This file is part of the KDAB State Machine Editor Library.
 //
-// SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+// SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 // Author: Kevin Funk <kevin.funk@kdab.com>
 //
 // SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/debuginterface/debuginterface_types.h
+++ b/src/debuginterface/debuginterface_types.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/debuginterface/debuginterfaceclient/CMakeLists.txt
+++ b/src/debuginterface/debuginterfaceclient/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KDAB State Machine Editor Library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Kevin Funk <kevin.funk@kdab.com>
 #
 # SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/debuginterface/debuginterfaceclient/debuginterfaceclient.cpp
+++ b/src/debuginterface/debuginterfaceclient/debuginterfaceclient.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/debuginterface/debuginterfaceclient/debuginterfaceclient.h
+++ b/src/debuginterface/debuginterfaceclient/debuginterfaceclient.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/debuginterface/debuginterfacesource/CMakeLists.txt
+++ b/src/debuginterface/debuginterfacesource/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KDAB State Machine Editor Library.
 #
-# SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Kevin Funk <kevin.funk@kdab.com>
 #
 # SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/debuginterface/debuginterfacesource/qscxmldebuginterfacesource.cpp
+++ b/src/debuginterface/debuginterfacesource/qscxmldebuginterfacesource.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2016-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/debuginterface/debuginterfacesource/qscxmldebuginterfacesource.h
+++ b/src/debuginterface/debuginterfacesource/qscxmldebuginterfacesource.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2016-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/debuginterface/debuginterfacesource/qsmdebuginterfacesource.cpp
+++ b/src/debuginterface/debuginterfacesource/qsmdebuginterfacesource.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/debuginterface/debuginterfacesource/qsmdebuginterfacesource.h
+++ b/src/debuginterface/debuginterfacesource/qsmdebuginterfacesource.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/debuginterface/debuginterfacesource/qsmwatcher.cpp
+++ b/src/debuginterface/debuginterfacesource/qsmwatcher.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/debuginterface/debuginterfacesource/qsmwatcher_p.h
+++ b/src/debuginterface/debuginterfacesource/qsmwatcher_p.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/CMakeLists.txt
+++ b/src/view/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KDAB State Machine Editor Library.
 #
-# SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Kevin Funk <kevin.funk@kdab.com>
 #
 # SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/abstractcontroller.cpp
+++ b/src/view/abstractcontroller.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/abstractcontroller.h
+++ b/src/view/abstractcontroller.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/abstractscene.cpp
+++ b/src/view/abstractscene.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/abstractscene.h
+++ b/src/view/abstractscene.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/abstractscene_p.h
+++ b/src/view/abstractscene_p.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2016-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/command/changestatemachinecommand.cpp
+++ b/src/view/command/changestatemachinecommand.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Sebastian Sauer <sebastian.sauer@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/command/changestatemachinecommand_p.h
+++ b/src/view/command/changestatemachinecommand_p.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Sebastian Sauer <sebastian.sauer@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/command/command.cpp
+++ b/src/view/command/command.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/command/command_p.h
+++ b/src/view/command/command_p.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/command/commandfactory.cpp
+++ b/src/view/command/commandfactory.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/command/commandfactory_p.h
+++ b/src/view/command/commandfactory_p.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/command/createelementcommand.cpp
+++ b/src/view/command/createelementcommand.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/command/createelementcommand_p.h
+++ b/src/view/command/createelementcommand_p.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/command/deleteelementcommand.cpp
+++ b/src/view/command/deleteelementcommand.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/command/deleteelementcommand_p.h
+++ b/src/view/command/deleteelementcommand_p.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/command/layoutsnapshotcommand.cpp
+++ b/src/view/command/layoutsnapshotcommand.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/command/layoutsnapshotcommand_p.h
+++ b/src/view/command/layoutsnapshotcommand_p.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/command/modifydefaultstatecommand.cpp
+++ b/src/view/command/modifydefaultstatecommand.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Volker Krause <volker.krause@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/command/modifydefaultstatecommand_p.h
+++ b/src/view/command/modifydefaultstatecommand_p.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Volker Krause <volker.krause@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/command/modifyelementcommand.cpp
+++ b/src/view/command/modifyelementcommand.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/command/modifyelementcommand_p.h
+++ b/src/view/command/modifyelementcommand_p.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/command/modifyinitialstatecommand.cpp
+++ b/src/view/command/modifyinitialstatecommand.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Volker Krause <volker.krause@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/command/modifyinitialstatecommand_p.h
+++ b/src/view/command/modifyinitialstatecommand_p.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Volker Krause <volker.krause@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/command/modifypropertycommand.cpp
+++ b/src/view/command/modifypropertycommand.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/command/modifypropertycommand_p.h
+++ b/src/view/command/modifypropertycommand_p.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/command/modifytransitioncommand.cpp
+++ b/src/view/command/modifytransitioncommand.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/command/modifytransitioncommand_p.h
+++ b/src/view/command/modifytransitioncommand_p.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/command/reparentelementcommand.cpp
+++ b/src/view/command/reparentelementcommand.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/command/reparentelementcommand_p.h
+++ b/src/view/command/reparentelementcommand_p.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/commandcontroller.cpp
+++ b/src/view/commandcontroller.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/commandcontroller.h
+++ b/src/view/commandcontroller.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/debug.cpp
+++ b/src/view/debug.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/debug.h
+++ b/src/view/debug.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/editcontroller.cpp
+++ b/src/view/editcontroller.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/editcontroller.h
+++ b/src/view/editcontroller.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/instantiatorinterface_p.h
+++ b/src/view/instantiatorinterface_p.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/qml/Scene.qml
+++ b/src/view/qml/Scene.qml
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/qml/SceneItemFactory.qml
+++ b/src/view/qml/SceneItemFactory.qml
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/qml/StateMachineView.qml
+++ b/src/view/qml/StateMachineView.qml
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/qml/StateMachineViewToolBar.qml
+++ b/src/view/qml/StateMachineViewToolBar.qml
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/qml/themes/DarkTheme.qml
+++ b/src/view/qml/themes/DarkTheme.qml
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2016-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/qml/themes/SystemTheme.qml
+++ b/src/view/qml/themes/SystemTheme.qml
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2016-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2016 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/qml/uml/UmlCompositeStateContent.qml
+++ b/src/view/qml/uml/UmlCompositeStateContent.qml
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/qml/uml/UmlCompositeStateDelegate.qml
+++ b/src/view/qml/uml/UmlCompositeStateDelegate.qml
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/qml/uml/UmlFinalState.qml
+++ b/src/view/qml/uml/UmlFinalState.qml
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/qml/uml/UmlHistoryState.qml
+++ b/src/view/qml/uml/UmlHistoryState.qml
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Sebastian Sauer <sebastian.sauer@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/qml/uml/UmlPseudoState.qml
+++ b/src/view/qml/uml/UmlPseudoState.qml
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/qml/uml/UmlSimpleStateDelegate.qml
+++ b/src/view/qml/uml/UmlSimpleStateDelegate.qml
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/qml/uml/UmlState.qml
+++ b/src/view/qml/uml/UmlState.qml
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/qml/uml/UmlStateMachine.qml
+++ b/src/view/qml/uml/UmlStateMachine.qml
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/qml/uml/UmlTransition.qml
+++ b/src/view/qml/uml/UmlTransition.qml
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/qml/util/ArrowHead.qml
+++ b/src/view/qml/util/ArrowHead.qml
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/qml/util/BirdEyeView.qml
+++ b/src/view/qml/util/BirdEyeView.qml
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/qml/util/ChannelizedDropArea.qml
+++ b/src/view/qml/util/ChannelizedDropArea.qml
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/qml/util/DragPoint.qml
+++ b/src/view/qml/util/DragPoint.qml
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/qml/util/DragPointDelegate.qml
+++ b/src/view/qml/util/DragPointDelegate.qml
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/qml/util/DragPointGroup.qml
+++ b/src/view/qml/util/DragPointGroup.qml
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/qml/util/RectangularGlowQt5.qml
+++ b/src/view/qml/util/RectangularGlowQt5.qml
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor
 

--- a/src/view/qml/util/RectangularGlowQt6.qml
+++ b/src/view/qml/util/RectangularGlowQt6.qml
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor
 

--- a/src/view/qml/util/RectangularGlowWrapper.qml
+++ b/src/view/qml/util/RectangularGlowWrapper.qml
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2021-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2021 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor
 

--- a/src/view/qml/util/RectangularSelectionHandler.qml
+++ b/src/view/qml/util/RectangularSelectionHandler.qml
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/qml/util/SquareButton.qml
+++ b/src/view/qml/util/SquareButton.qml
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/qml/util/Theme.qml
+++ b/src/view/qml/util/Theme.qml
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/qml/util/ToolBarSeparator.qml
+++ b/src/view/qml/util/ToolBarSeparator.qml
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/qml/util/ToolTip.qml
+++ b/src/view/qml/util/ToolTip.qml
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/qml/util/constants.js
+++ b/src/view/qml/util/constants.js
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/qml/util/functions.js
+++ b/src/view/qml/util/functions.js
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/quick/quickkdsmeglobal.cpp
+++ b/src/view/quick/quickkdsmeglobal.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/quick/quickkdsmeglobal_p.h
+++ b/src/view/quick/quickkdsmeglobal_p.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/quick/quickmaskedmousearea.cpp
+++ b/src/view/quick/quickmaskedmousearea.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/quick/quickmaskedmousearea_p.h
+++ b/src/view/quick/quickmaskedmousearea_p.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/quick/quickpainterpath.cpp
+++ b/src/view/quick/quickpainterpath.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/quick/quickpainterpath_p.h
+++ b/src/view/quick/quickpainterpath_p.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/quick/quickpen.cpp
+++ b/src/view/quick/quickpen.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/quick/quickpen_p.h
+++ b/src/view/quick/quickpen_p.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/quick/quickprimitiveitem.cpp
+++ b/src/view/quick/quickprimitiveitem.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/quick/quickprimitiveitem_p.h
+++ b/src/view/quick/quickprimitiveitem_p.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/quick/quickrecursiveinstantiator.cpp
+++ b/src/view/quick/quickrecursiveinstantiator.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/quick/quickrecursiveinstantiator_p.h
+++ b/src/view/quick/quickrecursiveinstantiator_p.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/quick/quicksceneitem.cpp
+++ b/src/view/quick/quicksceneitem.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/quick/quicksceneitem_p.h
+++ b/src/view/quick/quicksceneitem_p.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/semanticzoommanager.cpp
+++ b/src/view/semanticzoommanager.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/semanticzoommanager.h
+++ b/src/view/semanticzoommanager.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/statemachinescene.cpp
+++ b/src/view/statemachinescene.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/statemachinescene.h
+++ b/src/view/statemachinescene.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/statemachinescene_p.h
+++ b/src/view/statemachinescene_p.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/tests/CMakeLists.txt
+++ b/src/view/tests/CMakeLists.txt
@@ -1,7 +1,6 @@
-#
 # This file is part of the KDAB State Machine Editor Library.
 #
-# SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+# SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
 # Author: Kevin Funk <kevin.funk@kdab.com>
 #
 # SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/tests/test_commands.cpp
+++ b/src/view/tests/test_commands.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/tests/test_statemachineview.cpp
+++ b/src/view/tests/test_statemachineview.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2015-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2015 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/widgets/propertyeditor.cpp
+++ b/src/view/widgets/propertyeditor.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/widgets/propertyeditor.h
+++ b/src/view/widgets/propertyeditor.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/widgets/statemachinepalettewidget.cpp
+++ b/src/view/widgets/statemachinepalettewidget.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/widgets/statemachinepalettewidget.h
+++ b/src/view/widgets/statemachinepalettewidget.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/widgets/statemachinetoolbar.cpp
+++ b/src/view/widgets/statemachinetoolbar.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/widgets/statemachinetoolbar.h
+++ b/src/view/widgets/statemachinetoolbar.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/widgets/statemachineview.cpp
+++ b/src/view/widgets/statemachineview.cpp
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor

--- a/src/view/widgets/statemachineview.h
+++ b/src/view/widgets/statemachineview.h
@@ -1,7 +1,7 @@
 /*
   This file is part of the KDAB State Machine Editor Library.
 
-  SPDX-FileCopyrightText: 2014-2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+  SPDX-FileCopyrightText: 2014 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
   Author: Kevin Funk <kevin.funk@kdab.com>
 
   SPDX-License-Identifier: LGPL-2.1-only OR LicenseRef-KDAB-KDStateMachineEditor


### PR DESCRIPTION
For individual files: use year of file creation
For entire project:
  remove year from the statement
  use the © where feasible

reference:
https://matija.suklje.name/how-and-why-to-properly-write-copyright-statements-in-your-code