### PR TITLE
Install the Windows pdb files in the bin dir

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -141,7 +141,7 @@ install(
 if(MSVC)
     install(
         FILES "$<TARGET_PDB_FILE_DIR:kdstatemachineeditor_core>/$<TARGET_PDB_FILE_NAME:kdstatemachineeditor_core>"
-        DESTINATION ${LIB_INSTALL_DIR}
+        DESTINATION ${BIN_INSTALL_DIR}
         CONFIGURATIONS Debug RelWithDebInfo
     )
 endif()

--- a/src/debuginterface/debuginterfaceclient/CMakeLists.txt
+++ b/src/debuginterface/debuginterfaceclient/CMakeLists.txt
@@ -87,7 +87,7 @@ if(MSVC)
     install(
         FILES
             "$<TARGET_PDB_FILE_DIR:kdstatemachineeditor_debuginterfaceclient>/$<TARGET_PDB_FILE_NAME:kdstatemachineeditor_debuginterfaceclient>"
-        DESTINATION ${LIB_INSTALL_DIR}
+        DESTINATION ${BIN_INSTALL_DIR}
         CONFIGURATIONS Debug RelWithDebInfo
     )
 endif()

--- a/src/view/CMakeLists.txt
+++ b/src/view/CMakeLists.txt
@@ -100,7 +100,7 @@ install(
 if(MSVC)
     install(
         FILES "$<TARGET_PDB_FILE_DIR:kdstatemachineeditor_view>/$<TARGET_PDB_FILE_NAME:kdstatemachineeditor_view>"
-        DESTINATION ${LIB_INSTALL_DIR}
+        DESTINATION ${BIN_INSTALL_DIR}
         CONFIGURATIONS Debug RelWithDebInfo
     )
 endif()


### PR DESCRIPTION
Install the Windows pdb files in the bin (or runtime)
directory and not into the library dir.
