### PR TITLE
Fix build on Archlinux due to libgvplugin_dot_layout.so not being found

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,11 +1,12 @@
 Version 2.0.0: (unreleased):
 --------------
  * Supports Qt6 in addition to Qt5 (co-installable)
- * Buildsystem - increase CMake min version to 3.16.0
- * Buildsystem - add uninstall target
+ * Buildsystem: increase CMake min version to 3.16.0
+ * Buildsystem: add uninstall target
  * Buildsystem: generate and install kdsme-version.h
  * Use official Graphviz from upstream with -DWITH_INTERNAL_GRAPHVIZ=True
    (Bad side-effect: allows dynamic builds only)
+ * Fixed build with more recent graphviz versions
 
 Version 1.2.8:
 --------------

--- a/cmake/FindGraphviz.cmake
+++ b/cmake/FindGraphviz.cmake
@@ -120,6 +120,13 @@ find_library(
     PATH_SUFFIXES ${GRAPHVIZ_LIB_PATH_SUFFIX} ${_GRAPHVIZ_FIND_OPTS}
 )
 
+find_library(
+    GRAPHVIZ_PLUGIN_DOT_LAYOUT_LIBRARY
+    NAMES gvplugin_dot_layout
+    HINTS ${_GRAPHVIZ_LIBRARY_DIR}
+    PATH_SUFFIXES ${GRAPHVIZ_LIB_PATH_SUFFIX} ${_GRAPHVIZ_FIND_OPTS} graphviz
+)
+
 cmake_push_check_state()
 if(NOT DEFINED CMAKE_REQUIRED_INCLUDES)
     set(CMAKE_REQUIRED_INCLUDES "") #to make --warn-uninitialized happy

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -110,8 +110,12 @@ endif()
 
 generate_export_header(kdstatemachineeditor_core EXPORT_FILE_NAME kdsme_core_export.h BASE_NAME KDSME_CORE)
 
+if (NOT GRAPHVIZ_PLUGIN_DOT_LAYOUT_LIBRARY)
+    set(GRAPHVIZ_PLUGIN_DOT_LAYOUT_LIBRARY gvplugin_dot_layout)
+endif()
+
 if(GRAPHVIZ_FOUND)
-    target_link_libraries(kdstatemachineeditor_core PRIVATE cgraph gvc gvplugin_dot_layout)
+    target_link_libraries(kdstatemachineeditor_core PRIVATE cgraph gvc ${GRAPHVIZ_PLUGIN_DOT_LAYOUT_LIBRARY})
 endif()
 
 set(build_iface_dirs

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -110,7 +110,7 @@ endif()
 
 generate_export_header(kdstatemachineeditor_core EXPORT_FILE_NAME kdsme_core_export.h BASE_NAME KDSME_CORE)
 
-if (NOT GRAPHVIZ_PLUGIN_DOT_LAYOUT_LIBRARY)
+if(NOT GRAPHVIZ_PLUGIN_DOT_LAYOUT_LIBRARY)
     set(GRAPHVIZ_PLUGIN_DOT_LAYOUT_LIBRARY gvplugin_dot_layout)
 endif()
 


### PR DESCRIPTION
On Archlinux, it's in /usr/lib/graphviz/ not /usr/lib

Adapted FindGraphviz.cmake to find the full location and use it if found.