### PR TITLE
docs: Update building instructions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,9 @@
 # (See INSTALL.txt for more information)
 #
 # -DWITH_INTERNAL_GRAPHVIZ=[true|false]
-#  Allow to build with an internal Graphviz install.
-#  In the case where a separate Graphviz installation is not practical or desired.
+#  Allow to build with an external Graphviz install.
+#  We build with our internal graphviz sub-module but someone might want to
+#  build against distro package, which is not recommended and probably broken.
 #  Default=true
 #
 # -WITH_STATIC_GRAPHVIZ=[true|false]

--- a/README.md
+++ b/README.md
@@ -78,17 +78,6 @@ configuration changes of the state machine, as well as zooming into child state 
 
 ## Building and running
 
-We strongly recommend installing [Graphviz](https://graphviz.org):
-
-```bash
-    (Ubuntu) sudo apt install graphviz graphviz-dev
-    (Fedora) dnf install graphviz graphviz-devel
-    (Mac) brew install graphviz
-    (Windows) choco install graphviz
-```
-
-of course you need a Qt5 or Qt6 installation and CMake too.
-
 ### Build
 
 Make sure you have cmake, ninja, compiler, Qt, etc in PATH.
@@ -100,6 +89,8 @@ Make sure you have cmake, ninja, compiler, Qt, etc in PATH.
     cmake --build
     cmake --build . --target install
 ```
+
+Pass `-DBUILD_QT6=ON` for a Qt 6 build.
 
 ### Start the test app
 


### PR DESCRIPTION
- Mention the Qt6 flag
- Do not encourage people to build with distro graphviz, it's a burden to get working as it frequently breaks. The CMake code still allows it , for hackers only.