### PR TITLE
cmake: Minor cleanup regarding cmake_policy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ project(
 
 set(KDSME_SOVERSION "2") #means the 2.x ABI is frozen. ABI changes will must go to version 3
 
-if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.31)
+if(POLICY CMP0177)
     # Silence cmake warning about normalizing paths in install()
     # Please add "make install" tests to CI before using the newer policy
     cmake_policy(SET CMP0177 OLD) # CMake normalizes install paths


### PR DESCRIPTION
Use POLICY to guard against old cmake version not knowing about the policy. No behavior change, just cleaner.