### PR TITLE
Rename cmake options

### DIFF
--- a/.github/workflows/build-external-graphviz.yml
+++ b/.github/workflows/build-external-graphviz.yml
@@ -67,12 +67,12 @@ jobs:
           --warn-uninitialized -Werror=dev
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
           -DCMAKE_OSX_ARCHITECTURES="arm64"
-          -DBUILD_QT6=ON
-          -DBUILD_TESTS=${{ matrix.build_type == 'Debug' }}
-          -DBUILD_EXAMPLES=ON
-          -DBUILD_DOCS=${{ matrix.build_type == 'Debug' && runner.os == 'Linux' }}
-          -DBUILD_STATIC=${{ matrix.lib_type == 'Static' }}
-          -DWITH_INTERNAL_GRAPHVIZ=OFF
+          -DKDSME_QT6=ON
+          -DBUILD_TESTING=${{ matrix.build_type == 'Debug' }}
+          -DKDSME_EXAMPLES=ON
+          -DKDSME_DOCS=${{ matrix.build_type == 'Debug' && runner.os == 'Linux' }}
+          -DBUILD_SHARED_LIBS=${{ matrix.lib_type == 'Shared' }}
+          -DKDSME_INTERNAL_GRAPHVIZ=OFF
 
       - name: Build Project
         run: cmake --build ./build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,11 +90,11 @@ jobs:
           --warn-uninitialized -Werror=dev
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
           -DCMAKE_OSX_ARCHITECTURES="${{ matrix.config.macos_architectures }}"
-          -DBUILD_QT6=${{ startsWith(matrix.config.qt_version, '6.') }}
-          -DBUILD_TESTS=${{ matrix.build_type == 'Debug' }}
-          -DBUILD_EXAMPLES=ON
-          -DBUILD_DOCS=${{ matrix.build_type == 'Debug' && runner.os == 'Linux' }}
-          -DBUILD_STATIC=${{ matrix.lib_type == 'Static' }}
+          -DKDSME_QT6=${{ startsWith(matrix.config.qt_version, '6.') }}
+          -DBUILD_TESTING=${{ matrix.build_type == 'Debug' }}
+          -DKDSME_EXAMPLES=ON
+          -DKDSME_DOCS=${{ matrix.build_type == 'Debug' && runner.os == 'Linux' }}
+          -DBUILD_SHARED_LIBS=${{ matrix.lib_type == 'Shared' }}
 
       - name: Build Project
         run: cmake --build ./build

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Configure project
         run: >
-          cmake -S . -B ./build -DBUILD_DOCS=ON
+          cmake -S . -B ./build -DKDSME_DOCS=ON
 
       - name: Create docs
         run: cmake --build ./build --target docs

--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -13,12 +13,12 @@
 # Contact info@kdab.com if any conditions of this licensing are not clear to you.
 #
 
-if(WITH_INTERNAL_GRAPHVIZ)
+if(KDSME_INTERNAL_GRAPHVIZ)
     # Function creates extra scope to keep these variables local
     function(add_graphviz_subdirectory)
         #TODO check if there are unneeded features to disable
 
-        if(WITH_STATIC_GRAPHVIZ)
+        if(KDSME_STATIC_GRAPHVIZ)
             set(BUILD_SHARED_LIBS OFF)
         endif()
         if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/graphviz/CMakeLists.txt")

--- a/CHANGES
+++ b/CHANGES
@@ -7,7 +7,15 @@ Version 2.0.0:
  * Use official Graphviz from upstream with -DWITH_INTERNAL_GRAPHVIZ=True
    (Bad side-effect: allows dynamic builds only, but external graphviz still supported)
  * Fixed build with more recent graphviz versions
- * Buildsystem: new Option BUILD_STATIC to create static libraries
+ * Buildsystem: new Option BUILD_SHARED_LIBS to select between shared or static libraries
+ * Renamed the following CMake options
+   * BUILD_DOCS -> KDSME_DOCS
+   * BUILD_EXAMPLES -> KDSME_EXAMPLES
+   * BUILD_QT6 -> KDSME_QT6
+   * WITH_INTERNAL_GRAPHVIZ -> KDSME_INTERNAL_GRAPHVIZ
+   * WITH_STATIC_GRAPHVIZ -> KDSME_STATIC_GRAPHVIZ
+ * Use standard cmake options instead of custom ones:
+   * BUILD_TESTS -> BUILD_TESTING
 
 Version 1.2.8:
 --------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,37 +17,37 @@
 # Pass the following variables to cmake to control the build:
 # (See INSTALL.txt for more information)
 #
-# -DWITH_INTERNAL_GRAPHVIZ=[true|false]
+# -DKDSME_INTERNAL_GRAPHVIZ=[true|false]
 #  Allow to build with an external Graphviz install.
 #  We build with our internal graphviz sub-module but someone might want to
 #  build against distro package, which is not recommended and probably broken.
 #  Default=true
 #
-# -WITH_STATIC_GRAPHVIZ=[true|false]
+# -KDSME_STATIC_GRAPHVIZ=[true|false]
 #  Allow the internal Graphviz build to be statically.
 #  Currently shared graphviz builds on Windows have link issues.
 #  Default=true
 #
-# -DBUILD_QT6=[true|false]
+# -DKDSME_QT6=[true|false]
 #  Build against Qt6 rather than Qt5
 #  Default=false (Qt5 will be used even if Qt6 is available)
 #
-# -DBUILD_DOCS=[true|false]
+# -DKDSME_DOCS=[true|false]
 #  Build the documentation. Documentation is never built when cross-compiling.
 #  Default=true
 #
-# -DBUILD_EXAMPLES=[true|false]
+# -DKDSME_EXAMPLES=[true|false]
 #  Build the examples. Examples are never built when cross-compiling.
 #  Default=true
 #
-# -DBUILD_TESTS=[true|false]
+# -DBUILD_TESTING=[true|false]
 #  Build the test harness. Tests are never built when cross-compiling.
 #  Note: disabling tests also disables building the kdstatemachineeditor test application.
 #  Default=True
 #
-# -DBUILD_STATIC=[true|false]
-#  Build static libraries
-#  Default=false
+# -DBUILD_SHARED_LIBS=[true|false]
+#  Build shared libraries
+#  Default=true
 
 cmake_minimum_required(VERSION 3.16)
 
@@ -69,23 +69,38 @@ endif()
 
 include(FeatureSummary)
 
-if(CMAKE_CROSSCOMPILING)
-    set(BUILD_DOCS OFF)
-    set(BUILD_EXAMPLES OFF)
-    set(BUILD_TESTS OFF)
-else()
-    option(BUILD_DOCS "Build KDStateMachineEditor documentation" ON)
-    option(BUILD_EXAMPLES "Build examples directory" ON)
-    option(BUILD_TESTS "Build the test harness" ON)
-endif()
-option(BUILD_QT6 "Build against Qt 6" OFF)
-option(BUILD_STATIC "Build statically" OFF)
+# Declare an option as renamed, and eventually update the old cache entry
+function(renamed_option _old _new)
+    get_property(
+        _old_set
+        CACHE ${_old}
+        PROPERTY VALUE
+        SET
+    )
+    if(_old_set)
+        message(DEPRECATION "\"${_old}\" was renamed \"${_new}\". Cache entry will be updated.")
+        set_property(CACHE ${_new} PROPERTY VALUE ${${_old}})
+        unset(${_old} CACHE)
+    endif()
+endfunction()
 
-if(BUILD_STATIC)
-    set(BUILD_LIBRARY_MODE "STATIC")
+if(CMAKE_CROSSCOMPILING)
+    set(KDSME_DOCS OFF)
+    set(KDSME_EXAMPLES OFF)
+    set(BUILD_TESTING OFF)
 else()
-    set(BUILD_LIBRARY_MODE "SHARED")
+    option(KDSME_DOCS "Build KDStateMachineEditor documentation" ON)
+    option(KDSME_EXAMPLES "Build examples directory" ON)
+    option(BUILD_TESTING "Build the test harness" ON)
 endif()
+renamed_option(BUILD_DOCS KDSME_DOCS)
+renamed_option(BUILD_EXAMPLES KDSME_EXAMPLES)
+renamed_option(BUILD_TESTS BUILD_TESTING)
+
+option(KDSME_QT6 "Build against Qt 6" OFF)
+renamed_option(BUILD_QT6 KDSME_QT6)
+
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/ECM/modules")
@@ -106,7 +121,7 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 endif()
 
-if(BUILD_QT6)
+if(KDSME_QT6)
     set(QT_VERSION_MAJOR 6)
     set(QT_MIN_VERSION "6.1.0")
     find_package(
@@ -146,7 +161,7 @@ set_package_properties(
 )
 
 # QtXmlPatterns is removed since Qt6
-if(NOT BUILD_QT6)
+if(NOT KDSME_QT6)
     find_package(Qt5XmlPatterns ${QT_MIN_VERSION} CONFIG QUIET)
     set_package_properties(
         Qt5XmlPatterns PROPERTIES
@@ -199,7 +214,7 @@ set(LIB_INSTALL_DIR
     ${CMAKE_INSTALL_LIBDIR}
     CACHE STRING "Library install destination."
 )
-if(BUILD_QT6)
+if(KDSME_QT6)
     set(INCLUDE_INSTALL_ROOT ${CMAKE_INSTALL_INCLUDEDIR}/${CMAKE_PROJECT_NAME}${KDSME_LIBRARY_QTID})
 else()
     set(INCLUDE_INSTALL_ROOT ${CMAKE_INSTALL_INCLUDEDIR}/)
@@ -227,13 +242,16 @@ set(INSTALL_TARGETS_DEFAULT_ARGS
     "/Applications/Qt${QT_VERSION_MAJOR}"
 )
 
-option(WITH_INTERNAL_GRAPHVIZ "Enable internal build of external project Graphviz" ON)
-add_feature_info("Internal build of Graphviz" WITH_INTERNAL_GRAPHVIZ "disable with WITH_INTERNAL_GRAPHVIZ=OFF")
+option(KDSME_INTERNAL_GRAPHVIZ "Enable internal build of external project Graphviz" ON)
+renamed_option(WITH_INTERNAL_GRAPHVIZ KDSME_INTERNAL_GRAPHVIZ)
+add_feature_info("Internal build of Graphviz" KDSME_INTERNAL_GRAPHVIZ "disable with KDSME_INTERNAL_GRAPHVIZ=OFF")
 
-if(WITH_INTERNAL_GRAPHVIZ)
-    option(WITH_STATIC_GRAPHVIZ "Enable static build of Graphviz when internally building" ON)
+if(KDSME_INTERNAL_GRAPHVIZ)
+    option(KDSME_STATIC_GRAPHVIZ "Enable static build of Graphviz when internally building" ON)
+    renamed_option(WITH_STATIC_GRAPHVIZ KDSME_STATIC_GRAPHVIZ)
     add_feature_info(
-        "Statically build Graphviz for internal builds" WITH_INTERNAL_GRAPHVIZ "disable with WITH_STATIC_GRAPHVIZ=OFF"
+        "Statically build Graphviz for internal builds" KDSME_INTERNAL_GRAPHVIZ
+        "disable with KDSME_STATIC_GRAPHVIZ=OFF"
     )
     set(GRAPHVIZ_FOUND ON)
 
@@ -296,7 +314,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated -Wextra -Woverloaded-virtual -Winit-self")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wmissing-include-dirs -Wunused -Wno-div-by-zero -Wundef")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wpointer-arith -Wmissing-noreturn -Werror=return-type -Wswitch")
-    if(NOT BUILD_QT6)
+    if(NOT KDSME_QT6)
         if(HAVE_GXX_GNUXX11) # QNX needs gnu++0x rather than c++0x for compiling QML V4 private headers
             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++0x")
         elseif(HAVE_GXX_CXX11)
@@ -336,12 +354,12 @@ if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
 else()
     #Always disable tests, examples, docs when used as a submodule
     set(${PROJECT_NAME}_IS_ROOT_PROJECT FALSE)
-    set(BUILD_TESTS FALSE)
-    set(BUILD_EXAMPLES FALSE)
-    set(BUILD_DOCS FALSE)
+    set(BUILD_TESTING FALSE)
+    set(KDSME_EXAMPLES FALSE)
+    set(KDSME_DOCS FALSE)
 endif()
 
-if(BUILD_TESTS AND NOT CMAKE_CROSSCOMPILING)
+if(BUILD_TESTING AND NOT CMAKE_CROSSCOMPILING)
     enable_testing()
 endif()
 
@@ -349,11 +367,11 @@ set(TEST_DATA_DIR ${CMAKE_CURRENT_SOURCE_DIR}/data)
 
 add_subdirectory(src)
 
-if(BUILD_EXAMPLES)
+if(KDSME_EXAMPLES)
     add_subdirectory(examples)
 endif()
 
-if(BUILD_DOCS)
+if(KDSME_DOCS)
     add_subdirectory(docs)
 endif()
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -7,7 +7,7 @@
             "generator": "Ninja",
             "cacheVariables": {
                 "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
-                "BUILD_DOCS": "OFF"
+                "KDSME_DOCS": "OFF"
             }
         },
         {
@@ -18,7 +18,7 @@
             "binaryDir": "${sourceDir}/build-dev",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug",
-                "BUILD_TESTS": "ON"
+                "BUILD_TESTING": "ON"
             }
         },
         {
@@ -27,7 +27,7 @@
             "inherits": "dev-base",
             "binaryDir": "${sourceDir}/build-dev5-external-graphviz",
             "cacheVariables": {
-                "WITH_INTERNAL_GRAPHVIZ": "OFF"
+                "KDSME_INTERNAL_GRAPHVIZ": "OFF"
             }
         },
         {
@@ -36,7 +36,7 @@
             "inherits": "dev-base",
             "binaryDir": "${sourceDir}/build-dev5",
             "cacheVariables": {
-                "WITH_INTERNAL_GRAPHVIZ": "ON"
+                "KDSME_INTERNAL_GRAPHVIZ": "ON"
             }
         },
         {
@@ -45,8 +45,8 @@
             "inherits": "dev-base",
             "binaryDir": "${sourceDir}/build-dev6-external-graphviz",
             "cacheVariables": {
-                "BUILD_QT6": "ON",
-                "WITH_INTERNAL_GRAPHVIZ": "OFF"
+                "KDSME_QT6": "ON",
+                "KDSME_INTERNAL_GRAPHVIZ": "OFF"
             }
         },
         {
@@ -55,8 +55,8 @@
             "inherits": "dev-base",
             "binaryDir": "${sourceDir}/build-dev6",
             "cacheVariables": {
-                "BUILD_QT6": "ON",
-                "WITH_INTERNAL_GRAPHVIZ": "ON"
+                "KDSME_QT6": "ON",
+                "KDSME_INTERNAL_GRAPHVIZ": "ON"
             }
         },
         {
@@ -66,7 +66,7 @@
             "hidden": true,
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release",
-                "BUILD_TESTS": "OFF"
+                "BUILD_TESTING": "OFF"
             }
         },
         {
@@ -75,7 +75,7 @@
             "inherits": "rel-base",
             "binaryDir": "${sourceDir}/build-rel5-external-graphviz",
             "cacheVariables": {
-                "WITH_INTERNAL_GRAPHVIZ": "OFF"
+                "KDSME_INTERNAL_GRAPHVIZ": "OFF"
             }
         },
         {
@@ -84,7 +84,7 @@
             "inherits": "rel-base",
             "binaryDir": "${sourceDir}/build-rel5",
             "cacheVariables": {
-                "WITH_INTERNAL_GRAPHVIZ": "ON"
+                "KDSME_INTERNAL_GRAPHVIZ": "ON"
             }
         },
         {
@@ -93,8 +93,8 @@
             "inherits": "rel-base",
             "binaryDir": "${sourceDir}/build-rel6-external-graphviz",
             "cacheVariables": {
-                "BUILD_QT6": "ON",
-                "WITH_INTERNAL_GRAPHVIZ": "OFF"
+                "KDSME_QT6": "ON",
+                "KDSME_INTERNAL_GRAPHVIZ": "OFF"
             }
         },
         {
@@ -103,8 +103,8 @@
             "inherits": "rel-base",
             "binaryDir": "${sourceDir}/build-rel6",
             "cacheVariables": {
-                "BUILD_QT6": "ON",
-                "WITH_INTERNAL_GRAPHVIZ": "ON"
+                "KDSME_QT6": "ON",
+                "KDSME_INTERNAL_GRAPHVIZ": "ON"
             }
         }
     ]

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -42,8 +42,8 @@ Building on Windows with mingw:
 % mingw32-make install
 
 == Testing ==
-To build the testing harness, pass -DBUILD_TESTS=true to CMake, like so:
-  % cmake -DBUILD_TESTS=true
+To build the testing harness, pass -DBUILD_TESTING=true to CMake, like so:
+  % cmake -DBUILD_TESTING=true
 
 Then run 'make test' to run the unit tests.
 
@@ -68,7 +68,7 @@ on Windows you might want set "GRAPHVIZ_ROOT=C:\Program Files\Graphviz".
 
 When you run cmake it will inform you about missing dependencies.
 
-Graphviz can be built for you by passing the -DWITH_INTERNAL_GRAPHVIZ=True
+Graphviz can be built for you by passing the -DKDSME_INTERNAL_GRAPHVIZ=True
 option to CMake.  Be advised that Graphviz may have different minimum
 requirements for CMake, compiler, etc. than this software.
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Make sure you have cmake, ninja, compiler, Qt, etc in PATH.
     cmake --build . --target install
 ```
 
-Pass `-DBUILD_QT6=ON` for a Qt 6 build.
+Pass `-DKDSME_QT6=ON` for a Qt 6 build.
 
 ### Start the test app
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,8 +59,8 @@ before_build:
 build_script:
   - mkdir build
   - cd build
-  - cmd: cmake -G Ninja -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DBUILD_QT6=%useqt6% -DBUILD_TESTS=True -DBUILD_EXAMPLES=True ..
-  - sh: cmake -G Ninja -DCMAKE_BUILD_TYPE=$CONFIGURATION -DBUILD_QT6=$useqt6 -DBUILD_TESTS=True -DBUILD_EXAMPLES=True ..
+  - cmd: cmake -G Ninja -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DKDSME_QT6=%useqt6% -DBUILD_TESTING=True -DKDSME_EXAMPLES=True ..
+  - sh: cmake -G Ninja -DCMAKE_BUILD_TYPE=$CONFIGURATION -DKDSME_QT6=$useqt6 -DBUILD_TESTING=True -DKDSME_EXAMPLES=True ..
   - cmake --build .
   - cmd: cmake --build . --target install
   - sh: sudo cmake --build . --target install

--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -54,10 +54,10 @@ class KDStateMachineEditorConan(ConanFile):
 
     def build(self):
         self.cmake = CMake(self)
-        self.cmake.definitions["WITH_INTERNAL_GRAPHVIZ"] = True
-        self.cmake.definitions["BUILD_EXAMPLES"] = self.options.build_examples
-        self.cmake.definitions["BUILD_DOCS"] = self.options.build_docs
-        self.cmake.definitions["BUILD_TESTS"] = self.options.build_tests
+        self.cmake.definitions["KDSME_INTERNAL_GRAPHVIZ"] = True
+        self.cmake.definitions["KDSME_EXAMPLES"] = self.options.build_examples
+        self.cmake.definitions["KDSME_DOCS"] = self.options.build_docs
+        self.cmake.definitions["BUILD_TESTING"] = self.options.build_tests
         self.cmake.configure()
         self.cmake.build()
 

--- a/examples/qscxmldebugger/CMakeLists.txt
+++ b/examples/qscxmldebugger/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 add_executable(qscxmldebugger trafficlight.cpp main.cpp trafficlight-widgets-static.qrc)
 # Copy the .rep file to your project
-if(NOT BUILD_QT6)
+if(NOT KDSME_QT6)
     qt_generate_repc(REPC_SRCS ../../src/debuginterface/debuginterface.rep REPLICA)
 
     qt_add_statecharts(STATECHART_SRCS statemachine.scxml)
@@ -24,7 +24,7 @@ if(NOT BUILD_QT6)
     set_source_files_properties(${STATECHART_SRCS} PROPERTIES GENERATED TRUE SKIP_AUTOGEN ON)
     target_sources(qscxmldebugger PRIVATE ${REPC_SRCS} ${STATECHART_SRCS})
 endif()
-if(BUILD_QT6)
+if(KDSME_QT6)
     qt_add_repc_replicas(qscxmldebugger ../../src/debuginterface/debuginterface.rep)
     qt_add_statecharts(qscxmldebugger statemachine.scxml)
 endif()

--- a/examples/qsmdebugger/CMakeLists.txt
+++ b/examples/qsmdebugger/CMakeLists.txt
@@ -14,11 +14,11 @@
 
 set(SRCS trafficlight.cpp main.cpp)
 # Copy the .rep file to your project
-if(NOT BUILD_QT6)
+if(NOT KDSME_QT6)
     qt5_generate_repc(SRCS ../../src/debuginterface/debuginterface.rep REPLICA)
 endif()
 add_executable(qsmdebugger ${SRCS})
-if(BUILD_QT6)
+if(KDSME_QT6)
     qt6_add_repc_replicas(qsmdebugger ../../src/debuginterface/debuginterface.rep)
     target_link_libraries(qsmdebugger Qt6::StateMachine)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,6 +34,6 @@ if(TARGET Qt${QT_VERSION_MAJOR}::RemoteObjects)
     add_subdirectory(debuginterface)
 endif()
 
-if(BUILD_TESTS)
+if(BUILD_TESTING)
     add_subdirectory(app)
 endif()

--- a/src/config-kdsme.h.cmake
+++ b/src/config-kdsme.h.cmake
@@ -23,6 +23,6 @@
 
 #cmakedefine01 HAVE_GRAPHVIZ
 
-#cmakedefine01 WITH_STATIC_GRAPHVIZ
+#cmakedefine01 KDSME_STATIC_GRAPHVIZ
 
 #endif

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -72,12 +72,12 @@ if(GRAPHVIZ_FOUND)
         layout/graphvizlayout/gvutils.cpp
         layout/graphvizlayout/gvutils.h
     )
-    if(WITH_STATIC_GRAPHVIZ)
+    if(KDSME_STATIC_GRAPHVIZ)
         list(APPEND LIB_SRCS layout/graphvizlayout/graphviz_staticbuild.c)
     endif()
 endif()
 
-add_library(kdstatemachineeditor_core ${BUILD_LIBRARY_MODE} ${LIB_SRCS})
+add_library(kdstatemachineeditor_core ${LIB_SRCS})
 add_library(KDSME::Core ALIAS kdstatemachineeditor_core)
 target_link_libraries(
     kdstatemachineeditor_core
@@ -85,11 +85,11 @@ target_link_libraries(
     PUBLIC Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Gui
 )
 
-if(BUILD_QT6)
+if(KDSME_QT6)
     target_link_libraries(kdstatemachineeditor_core PRIVATE Qt6::StateMachine)
 endif()
 
-if(NOT WITH_INTERNAL_GRAPHVIZ)
+if(NOT KDSME_INTERNAL_GRAPHVIZ)
     target_include_directories(kdstatemachineeditor_core PRIVATE ${GRAPHVIZ_INCLUDE_DIR})
 endif()
 
@@ -114,7 +114,7 @@ endif()
 
 generate_export_header(kdstatemachineeditor_core EXPORT_FILE_NAME kdsme_core_export.h BASE_NAME KDSME_CORE)
 
-if(WITH_INTERNAL_GRAPHVIZ)
+if(KDSME_INTERNAL_GRAPHVIZ)
     set(GRAPHVIZ_GVC_LIBRARY gvc)
     set(GRAPHVIZ_CGRAPH_LIBRARY cgraph)
     if(NOT GRAPHVIZ_PLUGIN_DOT_LAYOUT_LIBRARY)
@@ -140,13 +140,13 @@ target_include_directories(
 
 set_target_properties(kdstatemachineeditor_core PROPERTIES OUTPUT_NAME "kdstatemachineeditor_core${KDSME_LIBRARY_QTID}")
 
-if(WITH_INTERNAL_GRAPHVIZ)
+if(KDSME_INTERNAL_GRAPHVIZ)
     install(
         TARGETS gvc cgraph cdt gvplugin_dot_layout dotgen
         EXPORT KDSME_TARGETS
         ${INSTALL_TARGETS_DEFAULT_ARGS}
     )
-    if(WITH_STATIC_GRAPHVIZ)
+    if(KDSME_STATIC_GRAPHVIZ)
         install(
             TARGETS common pack ortho pathplan label xdot
             EXPORT KDSME_TARGETS
@@ -159,7 +159,7 @@ install(
     EXPORT KDSME_TARGETS
     ${INSTALL_TARGETS_DEFAULT_ARGS}
 )
-if(MSVC AND NOT BUILD_STATIC)
+if(MSVC AND BUILD_SHARED_LIBS)
     install(
         FILES "$<TARGET_PDB_FILE_DIR:kdstatemachineeditor_core>/$<TARGET_PDB_FILE_NAME:kdstatemachineeditor_core>"
         DESTINATION ${BIN_INSTALL_DIR}
@@ -189,7 +189,7 @@ install(
     DESTINATION ${INCLUDE_INSTALL_DIR}/core
 )
 
-if(NOT BUILD_QT6)
+if(NOT KDSME_QT6)
     ecm_generate_pri_file(
         BASE_NAME
         KDSMECore
@@ -205,6 +205,6 @@ if(NOT BUILD_QT6)
     install(FILES ${PRI_FILENAME} DESTINATION ${ECM_MKSPECS_INSTALL_DIR})
 endif()
 
-if(BUILD_TESTS)
+if(BUILD_TESTING)
     add_subdirectory(tests)
 endif()

--- a/src/core/layout/graphvizlayout/graphvizlayouterbackend.cpp
+++ b/src/core/layout/graphvizlayout/graphvizlayouterbackend.cpp
@@ -399,7 +399,7 @@ void GraphvizLayouterBackend::Private::importTransition(Transition *transition, 
 }
 
 extern "C" {
-#if WITH_STATIC_GRAPHVIZ
+#if KDSME_STATIC_GRAPHVIZ
 GVC_t *gvContextWithStaticPlugins();
 #endif
 }
@@ -516,7 +516,7 @@ Agnode_t *GraphvizLayouterBackend::Private::agnodeForState(State *state)
     return static_cast<Agnode_t *>(m_elementToPointerMap.value(state));
 }
 
-#if !WITH_STATIC_GRAPHVIZ && !defined(Q_OS_WINDOWS)
+#if !KDSME_STATIC_GRAPHVIZ && !defined(Q_OS_WINDOWS)
 extern "C" {
 
 extern gvplugin_library_t gvplugin_dot_layout_LTX_library;
@@ -532,7 +532,7 @@ GraphvizLayouterBackend::GraphvizLayouterBackend()
     : d(new Private)
 {
     // create context
-#if WITH_STATIC_GRAPHVIZ
+#if KDSME_STATIC_GRAPHVIZ
     d->m_context = gvContextWithStaticPlugins();
 #elif !defined(Q_OS_WINDOWS)
     d->m_context = gvContextPlugins(lt_preloaded_symbols, 1);

--- a/src/core/tests/CMakeLists.txt
+++ b/src/core/tests/CMakeLists.txt
@@ -35,7 +35,7 @@ ecm_add_test(test_qmlexport.cpp LINK_LIBRARIES kdsme_testhelper)
 
 if(TARGET Qt::RemoteObjects)
     set(SRCS test_qsmintegration.cpp)
-    if(NOT BUILD_QT6)
+    if(NOT KDSME_QT6)
         qt_generate_repc(SRCS ../../debuginterface/debuginterface.rep REPLICA)
     endif()
     ecm_add_test(
@@ -49,7 +49,7 @@ if(TARGET Qt::RemoteObjects)
         kdstatemachineeditor_debuginterfacesource
         kdsme_testhelper
     )
-    if(BUILD_QT6)
+    if(KDSME_QT6)
         target_link_libraries(test_qsmintegration Qt6::StateMachine)
         qt_add_repc_replicas(test_qsmintegration ../../debuginterface/debuginterface.rep)
     endif()
@@ -67,9 +67,9 @@ ecm_add_test(test_statemachine.cpp LINK_LIBRARIES kdsme_testhelper)
 
 ecm_add_test(test_util.cpp LINK_LIBRARIES Qt::Gui kdsme_testhelper)
 
-if(NOT BUILD_QT6 OR Qt6Core5Compat_FOUND)
+if(NOT KDSME_QT6 OR Qt6Core5Compat_FOUND)
     ecm_add_test(test_layoutinformation.cpp LINK_LIBRARIES Qt::Gui Qt::Test kdstatemachineeditor_core)
-    if(BUILD_QT6)
+    if(KDSME_QT6)
         target_link_libraries(test_layoutinformation Qt6::Core5Compat)
     endif()
 endif()

--- a/src/debuginterface/debuginterfaceclient/CMakeLists.txt
+++ b/src/debuginterface/debuginterfaceclient/CMakeLists.txt
@@ -13,13 +13,13 @@
 #
 
 set(DEBUGINTERFACECLIENT_SRCS debuginterfaceclient.cpp)
-if(NOT BUILD_QT6)
+if(NOT KDSME_QT6)
     qt5_generate_repc(DEBUGINTERFACECLIENT_SRCS ../debuginterface.rep REPLICA)
 endif()
 
-add_library(kdstatemachineeditor_debuginterfaceclient ${BUILD_LIBRARY_MODE} ${DEBUGINTERFACECLIENT_SRCS})
+add_library(kdstatemachineeditor_debuginterfaceclient ${DEBUGINTERFACECLIENT_SRCS})
 
-if(BUILD_QT6)
+if(KDSME_QT6)
     qt6_add_repc_replicas(kdstatemachineeditor_debuginterfaceclient ../debuginterface.rep)
 endif()
 
@@ -58,7 +58,7 @@ target_include_directories(
     kdstatemachineeditor_debuginterfaceclient PUBLIC "$<BUILD_INTERFACE:${build_iface_dirs}>"
                                                      $<INSTALL_INTERFACE:${INCLUDE_INSTALL_ROOT}>
 )
-if(NOT BUILD_QT6)
+if(NOT KDSME_QT6)
     ecm_generate_pri_file(
         BASE_NAME
         KDSMEDebugInterfaceClient
@@ -82,7 +82,7 @@ install(
     EXPORT KDSME_TARGETS
     ${INSTALL_TARGETS_DEFAULT_ARGS}
 )
-if(MSVC AND NOT BUILD_STATIC)
+if(MSVC AND BUILD_SHARED_LIBS)
     # cmake-lint: disable=C0301
     install(
         FILES

--- a/src/debuginterface/debuginterfacesource/CMakeLists.txt
+++ b/src/debuginterface/debuginterfacesource/CMakeLists.txt
@@ -18,13 +18,13 @@ if(Qt${QT_VERSION_MAJOR}Scxml_FOUND)
     list(APPEND QSMDEBUGINTERFACESOURCE_SRCS qscxmldebuginterfacesource.cpp)
 endif()
 
-if(NOT BUILD_QT6)
+if(NOT KDSME_QT6)
     qt5_generate_repc(QSMDEBUGINTERFACESOURCE_SRCS ../debuginterface.rep SOURCE)
 endif()
 
 add_library(kdstatemachineeditor_debuginterfacesource STATIC ${QSMDEBUGINTERFACESOURCE_SRCS})
 
-if(BUILD_QT6)
+if(KDSME_QT6)
     qt6_add_repc_sources(kdstatemachineeditor_debuginterfacesource ../debuginterface.rep)
     target_link_libraries(kdstatemachineeditor_debuginterfacesource LINK_PRIVATE Qt6::StateMachine)
 endif()
@@ -71,7 +71,7 @@ target_include_directories(
     PUBLIC $<INSTALL_INTERFACE:${INCLUDE_INSTALL_ROOT}>
     PRIVATE ../
 )
-if(NOT BUILD_QT6)
+if(NOT KDSME_QT6)
     ecm_generate_pri_file(
         BASE_NAME
         KDSMEDebugInterfaceSource

--- a/src/view/CMakeLists.txt
+++ b/src/view/CMakeLists.txt
@@ -17,7 +17,6 @@ file(GLOB_RECURSE QML_JS_FILES *.qml *.js)
 
 add_library(
     kdstatemachineeditor_view
-    ${BUILD_LIBRARY_MODE}
     command/command.cpp
     command/commandfactory.cpp
     command/createelementcommand.cpp
@@ -98,7 +97,7 @@ install(
     EXPORT KDSME_TARGETS
     ${INSTALL_TARGETS_DEFAULT_ARGS}
 )
-if(MSVC AND NOT BUILD_STATIC)
+if(MSVC AND BUILD_SHARED_LIBS)
     install(
         FILES "$<TARGET_PDB_FILE_DIR:kdstatemachineeditor_view>/$<TARGET_PDB_FILE_NAME:kdstatemachineeditor_view>"
         DESTINATION ${BIN_INSTALL_DIR}
@@ -119,7 +118,7 @@ install(
     DESTINATION ${INCLUDE_INSTALL_DIR}/view
 )
 
-if(NOT BUILD_QT6)
+if(NOT KDSME_QT6)
     ecm_generate_pri_file(
         BASE_NAME
         KDSMEView
@@ -135,6 +134,6 @@ if(NOT BUILD_QT6)
     install(FILES ${PRI_FILENAME} DESTINATION ${ECM_MKSPECS_INSTALL_DIR})
 endif()
 
-if(BUILD_TESTS)
+if(BUILD_TESTING)
     add_subdirectory(tests)
 endif()


### PR DESCRIPTION
Following the conventions used in the other KD* repositories, use variables with a name that start with the project name.

Renamed options:

 * BUILD_DOCS -> KDSME_DOCS
 * BUILD_EXAMPLES -> KDSME_EXAMPLES
 * BUILD_QT6 -> KDSME_QT6
 * WITH_INTERNAL_GRAPHVIZ -> KDSME_INTERNAL_GRAPHVIZ
 * WITH_STATIC_GRAPHVIZ -> KDSME_STATIC_GRAPHVIZ

Use standard cmake options instead of custom ones:

   * BUILD_TESTS -> BUILD_TESTING
   * BUILD_STATIC -> BUILD_SHARED_LIBS

Cache entries are automatically updated.