### PR TITLE
KDStateMachineEditor now looks for Qt6 by default, rather than Qt5.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+Version 2.1.0: (unreleased)
+--------------
+ * KDStateMachineEditor now looks for Qt6 by default, rather than Qt5. If your Qt5
+   build broke, pass -DKDStateMachineEditor_QT6=OFF to CMake.
+
 Version 2.0.0:
 --------------
  * Supports Qt6 in addition to Qt5 (co-installable)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@
 #
 # -DKDSME_QT6=[true|false]
 #  Build against Qt6 rather than Qt5
-#  Default=false (Qt5 will be used even if Qt6 is available)
+#  Default=true
 #
 # -DKDSME_DOCS=[true|false]
 #  Build the documentation. Documentation is never built when cross-compiling.
@@ -97,7 +97,7 @@ renamed_option(BUILD_DOCS KDSME_DOCS)
 renamed_option(BUILD_EXAMPLES KDSME_EXAMPLES)
 renamed_option(BUILD_TESTS BUILD_TESTING)
 
-option(KDSME_QT6 "Build against Qt 6" OFF)
+option(KDSME_QT6 "Build against Qt 6" ON)
 renamed_option(BUILD_QT6 KDSME_QT6)
 
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -27,6 +27,7 @@
             "inherits": "dev-base",
             "binaryDir": "${sourceDir}/build-dev5-external-graphviz",
             "cacheVariables": {
+                "KDSME_QT6": "OFF",
                 "KDSME_INTERNAL_GRAPHVIZ": "OFF"
             }
         },
@@ -36,6 +37,7 @@
             "inherits": "dev-base",
             "binaryDir": "${sourceDir}/build-dev5",
             "cacheVariables": {
+                "KDSME_QT6": "OFF",
                 "KDSME_INTERNAL_GRAPHVIZ": "ON"
             }
         },
@@ -66,6 +68,7 @@
             "hidden": true,
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release",
+                "KDSME_QT6": "OFF",
                 "BUILD_TESTING": "OFF"
             }
         },
@@ -75,6 +78,7 @@
             "inherits": "rel-base",
             "binaryDir": "${sourceDir}/build-rel5-external-graphviz",
             "cacheVariables": {
+                "KDSME_QT6": "OFF",
                 "KDSME_INTERNAL_GRAPHVIZ": "OFF"
             }
         },
@@ -84,6 +88,7 @@
             "inherits": "rel-base",
             "binaryDir": "${sourceDir}/build-rel5",
             "cacheVariables": {
+                "KDSME_QT6": "OFF",
                 "KDSME_INTERNAL_GRAPHVIZ": "ON"
             }
         },

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Make sure you have cmake, ninja, compiler, Qt, etc in PATH.
     cmake --build . --target install
 ```
 
-Pass `-DKDSME_QT6=ON` for a Qt 6 build.
+Pass `-DKDSME_QT6=OFF` for a Qt 5 build.
 
 ### Start the test app
 


### PR DESCRIPTION
If your Qt5 build broke, pass -DKDStateMachineEditor_QT6=OFF to CMake.