### PR TITLE
Fix build with Qt 6.9

### DIFF
--- a/src/view/quick/qopengl2pexvertexarray_p.h
+++ b/src/view/quick/qopengl2pexvertexarray_p.h
@@ -80,6 +80,8 @@ public:
     operator QPointF() const {return QPointF(x,y);}
 };
 
+Q_DECLARE_TYPEINFO(QOpenGLPoint, Q_PRIMITIVE_TYPE);
+
 struct QOpenGLRect
 {
     QOpenGLRect(const QRectF &r)
@@ -95,6 +97,8 @@ struct QOpenGLRect
 
     operator QRectF() const {return QRectF(left, top, right-left, bottom-top);}
 };
+
+Q_DECLARE_TYPEINFO(QOpenGLRect, Q_PRIMITIVE_TYPE);
 
 class QOpenGL2PEXVertexArray
 {


### PR DESCRIPTION
These private APIs have now changed and QDataBuffer checks that
the types are trivially destructible / trivially copyable.