### PR TITLE
ci: Build against both asan and ubsan Qt

### DIFF
--- a/.github/workflows/build-sanitizers.yml
+++ b/.github/workflows/build-sanitizers.yml
@@ -24,7 +24,7 @@ jobs:
         preset: ['dev6-asan']
         include:
           - preset: dev6-asan
-            qt-flavor: asan
+            qt-flavor: asan_ubsan
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4


### PR DESCRIPTION
The KDSME asan preset already enables both for KDSME itself. Now the Qt it builds against also has both.